### PR TITLE
Add private key support to SSHPlus

### DIFF
--- a/Files/install_sshplus.sh
+++ b/Files/install_sshplus.sh
@@ -15,9 +15,19 @@ sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd
 /etc/init.d/sshd restart
 
 # Prompt for SSH credentials
+AUTH_METHOD=$(whiptail --title "PeDitX OS SshPlus on passwall" --menu "Select authentication method" 15 50 2 \
+    "password" "Password" \
+    "key" "Private Key" 3>&1 1>&2 2>&3)
 HOST=$(whiptail --inputbox "Enter SSH Host:" 8 40 --title "PeDitX OS SshPlus on passwall" 3>&1 1>&2 2>&3)
 USER=$(whiptail --inputbox "Enter SSH Username:" 8 40 --title "PeDitX OS SshPlus on passwall" 3>&1 1>&2 2>&3)
-PASS=$(whiptail --passwordbox "Enter SSH Password:" 8 40 --title "PeDitX OS SshPlus on passwall" 3>&1 1>&2 2>&3)
+if [ "$AUTH_METHOD" = "password" ]; then
+    PASS=$(whiptail --passwordbox "Enter SSH Password:" 8 40 --title "PeDitX OS SshPlus on passwall" 3>&1 1>&2 2>&3)
+else
+    KEY_FILE="/etc/sshplus_id_rsa"
+    whiptail --msgbox "After closing this box, paste your private key and press Ctrl+D" 10 60
+    cat > "$KEY_FILE"
+    chmod 600 "$KEY_FILE"
+fi
 PORT=$(whiptail --inputbox "Enter SSH Port (e.g. 22 or 2222):" 8 40 "22" --title "PeDitX OS SshPlus on passwall" 3>&1 1>&2 2>&3)
 
 # Validate that PORT is a number
@@ -28,7 +38,11 @@ fi
 
 # Save SSH credentials
 CONFIG_FILE="/etc/sshplus.conf"
-echo -e "HOST=${HOST}\nUSER=${USER}\nPASS=${PASS}\nPORT=${PORT}" > "$CONFIG_FILE"
+if [ "$AUTH_METHOD" = "password" ]; then
+    echo -e "HOST=${HOST}\nUSER=${USER}\nPORT=${PORT}\nAUTH_METHOD=password\nPASS=${PASS}" > "$CONFIG_FILE"
+else
+    echo -e "HOST=${HOST}\nUSER=${USER}\nPORT=${PORT}\nAUTH_METHOD=key\nKEY_FILE=${KEY_FILE}" > "$CONFIG_FILE"
+fi
 
 # Create SSH service script
 cat > /etc/init.d/sshplus << EOF
@@ -38,7 +52,11 @@ STOP=10
 
 start() {
     . "$CONFIG_FILE"
-    screen -dmS sshplus sshpass -p "\$PASS" ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -D 8089 -N -p "\$PORT" "\$USER@\$HOST"
+    if [ "\$AUTH_METHOD" = "key" ]; then
+        screen -dmS sshplus ssh -i "\$KEY_FILE" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -D 8089 -N -p "\$PORT" "\$USER@\$HOST"
+    else
+        screen -dmS sshplus sshpass -p "\$PASS" ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -D 8089 -N -p "\$PORT" "\$USER@\$HOST"
+    fi
 }
 
 stop() {
@@ -109,12 +127,26 @@ show_menu() {
 }
 
 edit_config() {
+    AUTH_METHOD=$(whiptail --title "PeDitX OS SshPlus on passwall" --menu "Select authentication method" 15 50 2 \
+        "password" "Password" \
+        "key" "Private Key" 3>&1 1>&2 2>&3)
     HOST=$(whiptail --inputbox "Enter SSH Host:" 8 40 "$(grep HOST= "$CONFIG_FILE" | cut -d'=' -f2)" --title "PeDitX OS SshPlus on passwall" 3>&1 1>&2 2>&3)
     USER=$(whiptail --inputbox "Enter SSH Username:" 8 40 "$(grep USER= "$CONFIG_FILE" | cut -d'=' -f2)" --title "PeDitX OS SshPlus on passwall" 3>&1 1>&2 2>&3)
-    PASS=$(whiptail --passwordbox "Enter SSH Password:" 8 40 --title "PeDitX OS SshPlus on passwall" 3>&1 1>&2 2>&3)
+    if [ "$AUTH_METHOD" = "password" ]; then
+        PASS=$(whiptail --passwordbox "Enter SSH Password:" 8 40 --title "PeDitX OS SshPlus on passwall" 3>&1 1>&2 2>&3)
+    else
+        KEY_FILE="/etc/sshplus_id_rsa"
+        whiptail --msgbox "After closing this box, paste your private key and press Ctrl+D" 10 60
+        cat > "$KEY_FILE"
+        chmod 600 "$KEY_FILE"
+    fi
     PORT=$(whiptail --inputbox "Enter SSH Port (e.g. 22 or 2222):" 8 40 "$(grep PORT= "$CONFIG_FILE" | cut -d'=' -f2)" --title "PeDitX OS SshPlus on passwall" 3>&1 1>&2 2>&3)
 
-    echo -e "HOST=${HOST}\nUSER=${USER}\nPASS=${PASS}\nPORT=${PORT}" > "$CONFIG_FILE"
+    if [ "$AUTH_METHOD" = "password" ]; then
+        echo -e "HOST=${HOST}\nUSER=${USER}\nPORT=${PORT}\nAUTH_METHOD=password\nPASS=${PASS}" > "$CONFIG_FILE"
+    else
+        echo -e "HOST=${HOST}\nUSER=${USER}\nPORT=${PORT}\nAUTH_METHOD=key\nKEY_FILE=${KEY_FILE}" > "$CONFIG_FILE"
+    fi
 }
 
 start_ssh_service() {

--- a/README-ch.md
+++ b/README-ch.md
@@ -53,6 +53,13 @@ rm -f *.sh && wget https://raw.githubusercontent.com/peditx/SshPlus/refs/heads/m
 
 ```
 
+### 卸载
+若要移除 SSHPlus，请运行：
+
+```bash
+rm -f uninstall_sshplus.sh && wget https://raw.githubusercontent.com/peditx/SshPlus/refs/heads/main/Files/uninstall_sshplus.sh && sh uninstall_sshplus.sh
+```
+
 ---
 
 ## ✨ 核心功能  
@@ -71,8 +78,10 @@ rm -f *.sh && wget https://raw.githubusercontent.com/peditx/SshPlus/refs/heads/m
    - 编辑配置  
    - 监控活动连接  
 
-4. **自动创建服务**  
-   通过 init.d 服务确保连接在系统重启后仍然保持稳定  
+4. **自动创建服务**
+   通过 init.d 服务确保连接在系统重启后仍然保持稳定
+5. **灵活的身份验证**
+   可选择密码或私钥方式连接
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ rm -f *.sh && wget https://raw.githubusercontent.com/peditx/SshPlus/refs/heads/m
 
 ```
 
+### Uninstall
+Run the following if you wish to remove SSHPlus:
+
+```bash
+rm -f uninstall_sshplus.sh && wget https://raw.githubusercontent.com/peditx/SshPlus/refs/heads/main/Files/uninstall_sshplus.sh && sh uninstall_sshplus.sh
+```
+
 ---
 
 ## ✨ Key Capabilities
@@ -71,8 +78,10 @@ rm -f *.sh && wget https://raw.githubusercontent.com/peditx/SshPlus/refs/heads/m
    - Edit configurations
    - Monitor active connections
 
-4. **Auto-Service Creation**  
+4. **Auto-Service Creation**
    Persistent connections survive reboots via init.d service
+5. **Flexible Authentication**
+   Choose between password or private key when connecting
 
 ---
 

--- a/README_fa.md
+++ b/README_fa.md
@@ -53,6 +53,13 @@ rm -f *.sh && wget https://raw.githubusercontent.com/peditx/SshPlus/refs/heads/m
 
 ```
 
+### حذف برنامه
+در صورت نیاز به پاک کردن SSHPlus دستور زیر را اجرا کنید:
+
+```bash
+rm -f uninstall_sshplus.sh && wget https://raw.githubusercontent.com/peditx/SshPlus/refs/heads/main/Files/uninstall_sshplus.sh && sh uninstall_sshplus.sh
+```
+
 ---
 
 ## ✨ قابلیت‌های کلیدی  
@@ -71,8 +78,10 @@ rm -f *.sh && wget https://raw.githubusercontent.com/peditx/SshPlus/refs/heads/m
    - ویرایش تنظیمات  
    - نظارت بر اتصالات فعال  
 
-4. **ایجاد سرویس خودکار**  
-   حفظ اتصالات پایدار حتی پس از ریبوت از طریق سرویس init.d  
+4. **ایجاد سرویس خودکار**
+   حفظ اتصالات پایدار حتی پس از ریبوت از طریق سرویس init.d
+5. **احراز هویت انعطاف‌پذیر**
+   امکان اتصال با گذرواژه یا کلید خصوصی
 
 ---
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -53,6 +53,13 @@ rm -f *.sh && wget https://raw.githubusercontent.com/peditx/SshPlus/refs/heads/m
 
 ```
 
+### Удаление
+Чтобы полностью удалить SSHPlus, выполните:
+
+```bash
+rm -f uninstall_sshplus.sh && wget https://raw.githubusercontent.com/peditx/SshPlus/refs/heads/main/Files/uninstall_sshplus.sh && sh uninstall_sshplus.sh
+```
+
 ---
 
 ## ✨ Основные возможности  
@@ -71,8 +78,10 @@ rm -f *.sh && wget https://raw.githubusercontent.com/peditx/SshPlus/refs/heads/m
    - Редактирование конфигураций  
    - Мониторинг активных соединений  
 
-4. **Автоматическое создание сервисов**  
-   Поддержание постоянных соединений даже после перезагрузки через службу init.d  
+4. **Автоматическое создание сервисов**
+   Поддержание постоянных соединений даже после перезагрузки через службу init.d
+5. **Гибкая аутентификация**
+   Возможность подключения по паролю или приватному ключу
 
 ---
 


### PR DESCRIPTION
## Summary
- allow choosing password or private key during installation
- save key to `/etc/sshplus_id_rsa` and use it for the service
- update sshplus management script to edit authentication method
- document uninstall command in all READMEs and mention flexible auth

## Testing
- `bash -n Files/install_sshplus.sh`
- `bash -n Files/uninstall_sshplus.sh`


------
https://chatgpt.com/codex/tasks/task_e_686038af96f0832597dc8550fc1ed9e0